### PR TITLE
Fix url encode

### DIFF
--- a/pifx/__init__.py
+++ b/pifx/__init__.py
@@ -49,7 +49,7 @@ class PIFX:
             identifier_name = url_arg_matches.group(1)
             argument_content = url_arg_matches.group(2)
 
-            encoded_arg = six.moves.urllib.parse.quote_plus(argument_content)
+            encoded_arg = argument_content.replace(" ", "%20")
 
             return identifier_name + ":" + encoded_arg
 

--- a/pifx/__init__.py
+++ b/pifx/__init__.py
@@ -17,7 +17,7 @@
 
 from . import util
 import re
-import requests, json, six
+import requests, json
 
 class PIFX:
     """Main PIFX class"""
@@ -39,7 +39,7 @@ class PIFX:
         if ":" not in url_arg:
             # no identifiers
             # can encode entire argument
-            return six.moves.urllib.parse.quote_plus(url_arg)
+            return encode_url_path(url_arg)
         else:
             # identifier found
             # separate identifier string from argument
@@ -49,7 +49,7 @@ class PIFX:
             identifier_name = url_arg_matches.group(1)
             argument_content = url_arg_matches.group(2)
 
-            encoded_arg = argument_content.replace(" ", "%20")
+            encoded_arg = encode_url_path(argument_content)
 
             return identifier_name + ":" + encoded_arg
 

--- a/pifx/__init__.py
+++ b/pifx/__init__.py
@@ -39,7 +39,7 @@ class PIFX:
         if ":" not in url_arg:
             # no identifiers
             # can encode entire argument
-            return encode_url_path(url_arg)
+            return util.encode_url_path(url_arg)
         else:
             # identifier found
             # separate identifier string from argument
@@ -49,7 +49,7 @@ class PIFX:
             identifier_name = url_arg_matches.group(1)
             argument_content = url_arg_matches.group(2)
 
-            encoded_arg = encode_url_path(argument_content)
+            encoded_arg = util.encode_url_path(argument_content)
 
             return identifier_name + ":" + encoded_arg
 

--- a/pifx/util.py
+++ b/pifx/util.py
@@ -16,7 +16,6 @@
 #
 
 import json
-import urllib
 import six
 from .constants import A_OK_HTTP_CODES, A_ERROR_HTTP_CODES
 

--- a/pifx/util.py
+++ b/pifx/util.py
@@ -17,6 +17,7 @@
 
 import json
 import urllib
+import six
 from .constants import A_OK_HTTP_CODES, A_ERROR_HTTP_CODES
 
 def generate_auth_header(api_key):
@@ -53,7 +54,8 @@ def handle_error(response):
         raise Exception(raise_error)
     else:
         return True
+
 def encode_url_path(url):
     """Encodes the path url string replacing special characters with properly escaped sequences.  
     Not intended for use with query string parameters. """
-    return urllib.quote(url)
+    return six.moves.urllib.parse.quote(url)

--- a/pifx/util.py
+++ b/pifx/util.py
@@ -16,6 +16,7 @@
 #
 
 import json
+import urllib
 from .constants import A_OK_HTTP_CODES, A_ERROR_HTTP_CODES
 
 def generate_auth_header(api_key):
@@ -52,3 +53,7 @@ def handle_error(response):
         raise Exception(raise_error)
     else:
         return True
+def encode_url_path(url):
+    """Encodes the path url string replacing special characters with properly escaped sequences.  
+    Not intended for use with query string parameters. """
+    return urllib.quote(url)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 nose==1.3.7
 requests==2.9.0
 wheel==0.24.0
+six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 nose==1.3.7
 requests==2.9.0
 wheel==0.24.0
-six

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.2',
+    version='0.0.3',
 
     description="""PIFX is a Python library for the LIFX cloud HTTP API""",
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -22,3 +22,15 @@ def test_arg_tup_to_dict():
     assert generated_dict.get('test4') == None
     assert generated_dict.get('test2') == "abc123"
     assert generated_dict.get('test3') == "abc321"
+
+def test_encode_url_path():
+    url_path = "/12345/testing/words123"
+    expected_path = "/12345/testing/words123"
+    actual_path = url_encode_path(url_path)
+    assert actual_path == expected_path
+    
+    url_path = "/label:Living Room Lights/"
+    expected_path = "/label:Living%20Room%20Lights/"
+    actual_path = url_encode_path(url_path)
+    assert actual_path == expected_path
+    

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -24,13 +24,28 @@ def test_arg_tup_to_dict():
     assert generated_dict.get('test3') == "abc321"
 
 def test_encode_url_path():
-    url_path = "/12345/testing/words123"
-    expected_path = "/12345/testing/words123"
-    actual_path = url_encode_path(url_path)
+    url_path = "/12345/abcdef/"
+    expected_path = "/12345/abcdef/"
+    actual_path = util.encode_url_path(url_path)
     assert actual_path == expected_path
     
-    url_path = "/label:Living Room Lights/"
-    expected_path = "/label:Living%20Room%20Lights/"
-    actual_path = url_encode_path(url_path)
+    url_path = "Living Room Lights"
+    expected_path = "Living%20Room%20Lights"
+    actual_path = util.encode_url_path(url_path)
+    assert actual_path == expected_path
+
+    url_path = "Lights 1&2"
+    expected_path = "Lights%201%262"
+    actual_path = util.encode_url_path(url_path)
+    assert actual_path == expected_path
+
+    url_path = "Lights 1-5"
+    expected_path = "Lights%201-5"
+    actual_path = util.encode_url_path(url_path)
+    assert actual_path == expected_path
+
+    url_path = "Light #5"
+    expected_path = "Light%20%235"
+    actual_path = util.encode_url_path(url_path)
     assert actual_path == expected_path
     


### PR DESCRIPTION
Resolves [Issue 1](https://github.com/cydrobolt/pifx/issues/1).

Appears to be encoding `label:Hello World` to `label:Hello+World` which causes the selector to not match any lights.

Should instead encode to `label:Hello%20World`.