### PR TITLE
added fix for case-sensitive boolean params

### DIFF
--- a/pifx/util.py
+++ b/pifx/util.py
@@ -34,6 +34,10 @@ def arg_tup_to_dict(argument_tuples):
     data = dict()
     for arg_name, arg_val in argument_tuples:
         if arg_val != None:
+            if arg_val == True:
+                arg_val = "true"
+            elif arg_val == False:
+                arg_val = "false"
             data[arg_name] = arg_val
 
     return data


### PR DESCRIPTION
**Problem:** pulse_lights() and breathe_lights() functions return "422: Missing or malformed parameters" error.

**Reason:** It appears that boolean parameters in the HTTP API have suddenly become case-sensitive and require lowercase "true" and "false."

**Fix:** Convert True and False to "true" and "false" when formatting data for an HTTP request.